### PR TITLE
bump shiny to 1.6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 faicons==0.2.2
-shiny==1.1.0
+shiny==1.6.2
 shinywidgets==0.3.3
 plotly==5.24.1
 pandas==2.2.2


### PR DESCRIPTION
To pull the htmltools 0.7.0 compatibility fix: https://github.com/posit-dev/py-shiny/issues/2245